### PR TITLE
fix(HeapAsync.ts, Heap.ts): fix Symbol.iterator implementation

### DIFF
--- a/dist/heap-js.es5.js
+++ b/dist/heap-js.es5.js
@@ -943,15 +943,19 @@ var HeapAsync = /** @class */ (function () {
      * Iterator interface
      */
     HeapAsync.prototype[Symbol.iterator] = function () {
+        var cloned;
         return __generator$1(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    if (!this.length) return [3 /*break*/, 2];
-                    return [4 /*yield*/, this.pop()];
+                    cloned = this.clone();
+                    _a.label = 1;
                 case 1:
+                    if (!cloned.length) return [3 /*break*/, 3];
+                    return [4 /*yield*/, cloned.pop()];
+                case 2:
                     _a.sent();
-                    return [3 /*break*/, 0];
-                case 2: return [2 /*return*/];
+                    return [3 /*break*/, 1];
+                case 3: return [2 /*return*/];
             }
         });
     };
@@ -2086,15 +2090,19 @@ var Heap = /** @class */ (function () {
      * Iterator interface
      */
     Heap.prototype[Symbol.iterator] = function () {
+        var cloned;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    if (!this.length) return [3 /*break*/, 2];
-                    return [4 /*yield*/, this.pop()];
+                    cloned = this.clone();
+                    _a.label = 1;
                 case 1:
+                    if (!cloned.length) return [3 /*break*/, 3];
+                    return [4 /*yield*/, cloned.pop()];
+                case 2:
                     _a.sent();
-                    return [3 /*break*/, 0];
-                case 2: return [2 /*return*/];
+                    return [3 /*break*/, 1];
+                case 3: return [2 /*return*/];
             }
         });
     };

--- a/dist/heap-js.umd.js
+++ b/dist/heap-js.umd.js
@@ -949,15 +949,19 @@
          * Iterator interface
          */
         HeapAsync.prototype[Symbol.iterator] = function () {
+            var cloned;
             return __generator$1(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        if (!this.length) return [3 /*break*/, 2];
-                        return [4 /*yield*/, this.pop()];
+                        cloned = this.clone();
+                        _a.label = 1;
                     case 1:
+                        if (!cloned.length) return [3 /*break*/, 3];
+                        return [4 /*yield*/, cloned.pop()];
+                    case 2:
                         _a.sent();
-                        return [3 /*break*/, 0];
-                    case 2: return [2 /*return*/];
+                        return [3 /*break*/, 1];
+                    case 3: return [2 /*return*/];
                 }
             });
         };
@@ -2092,15 +2096,19 @@
          * Iterator interface
          */
         Heap.prototype[Symbol.iterator] = function () {
+            var cloned;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        if (!this.length) return [3 /*break*/, 2];
-                        return [4 /*yield*/, this.pop()];
+                        cloned = this.clone();
+                        _a.label = 1;
                     case 1:
+                        if (!cloned.length) return [3 /*break*/, 3];
+                        return [4 /*yield*/, cloned.pop()];
+                    case 2:
                         _a.sent();
-                        return [3 /*break*/, 0];
-                    case 2: return [2 /*return*/];
+                        return [3 /*break*/, 1];
+                    case 3: return [2 /*return*/];
                 }
             });
         };

--- a/src/Heap.ts
+++ b/src/Heap.ts
@@ -729,8 +729,10 @@ export class Heap<T> implements Iterable<T> {
    * Iterator interface
    */
   *[Symbol.iterator](): Iterator<T> {
-    while (this.length) {
-      yield this.pop() as T;
+    const cloned = this.clone();
+
+    while (cloned.length) {
+      yield cloned.pop() as T;
     }
   }
 

--- a/src/HeapAsync.ts
+++ b/src/HeapAsync.ts
@@ -658,8 +658,10 @@ export class HeapAsync<T> implements Iterable<Promise<T>> {
    * Iterator interface
    */
   *[Symbol.iterator](): Iterator<Promise<T>> {
-    while (this.length) {
-      yield this.pop() as Promise<T>;
+    const cloned = this.clone();
+    
+    while (cloned.length) {
+      yield cloned.pop() as Promise<T>;
     }
   }
 


### PR DESCRIPTION
Can't iterate over the heap more than once:

Problem:
```js
const numbers = [2, 3, 7, 5];

const h = Heap.heapify(numbers);

for(let num of h) {
 // do something
}

// the heap is empty due to the previous cycle
for(let num of h) {
 // something
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved heap iteration to ensure the original heap remains unchanged during iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->