### PR TITLE
Add `heap` vs `heap-js` benchmark (related issue #661)

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -7,7 +7,7 @@ const N = 100;
 
 const data = Array(N);
 for (let i = 0; i < N; i++) {
-  const value = Math.floor(MAX * Math.random() + MIN);
+  const value = Math.floor((MAX - MIN) * Math.random() + MIN);
   data[i] = value;
 }
 

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,3 +1,4 @@
+const HeapHeap = require('heap');
 const { Heap } = require('../dist/heap-js.umd');
 const { runBenchmark } = require('./benchmark.helpers');
 
@@ -128,6 +129,35 @@ for (const n of samples) {
         }
         array.sort();
         array.slice(0, n);
+      },
+    },
+  ]);
+}
+
+for (const n of samples) {
+  const heapHeap = new HeapHeap();
+  const heapJsHeap = new Heap();
+  runBenchmark(`heap vs heap-js: push + pop ${n}`, [
+    {
+      name: 'heap',
+      func: function () {
+        for (let i = 0; i < n; i++) {
+          heapHeap.push(data[i]);
+        }
+        for (let i = 0; i < n; i++) {
+          heapHeap.pop();
+        }
+      },
+    },
+    {
+      name: 'heap-js',
+      func: function () {
+        for (let i = 0; i < n; i++) {
+          heapJsHeap.push(data[i]);
+        }
+        for (let i = 0; i < n; i++) {
+          heapJsHeap.pop();
+        }
       },
     },
   ]);

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -139,7 +139,7 @@ for (const n of samples) {
   const heapJsHeap = new Heap();
   runBenchmark(`heap vs heap-js: push + pop ${n}`, [
     {
-      name: 'heap',
+      name: 'heap   ',
       func: function () {
         for (let i = 0; i < n; i++) {
           heapHeap.push(data[i]);

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint": "<9.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "heap": "^0.2.7",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "lint-staged": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,6 +2200,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+heap@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
+  integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
Adds a benchmark comparing `heap-js` with `heap` (which is much faster for some reason, see #661). This benchmark serves as a baseline / measurement for future optimizations to come.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new benchmark to compare the performance of two heap implementations.
  - Updated development dependencies to include the external heap package.

- **Bug Fixes**
  - Corrected the random data generation formula for benchmarks to ensure values are within the intended range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->